### PR TITLE
[New Resource] Add distribution_release_bundle_received (R) — 1 APIs

### DIFF
--- a/pkg/distribution/resource_release_bundle_received.go
+++ b/pkg/distribution/resource_release_bundle_received.go
@@ -1,0 +1,135 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ReceivedsEndpoint = "distribution/api/v2/release_bundle/received"
+	ReceivedEndpoint  = "distribution/api/v2/release_bundle/received/{name}/{version}"
+)
+
+func NewReleaseBundleReceivedResource() resource.Resource {
+	return &ReleaseBundleReceivedResource{
+		TypeName: "distribution_received",
+	}
+}
+
+type ReleaseBundleReceivedResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ReleaseBundleReceivedResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Version types.String `tfsdk:"version"`
+}
+
+type ReceivedAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (r *ReleaseBundleReceivedResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ReleaseBundleReceivedResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				Description: "The name of the resource.",
+			},
+			"version": schema.StringAttribute{
+				Required: true,
+				Description: "The version of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages received in JFrog Distribution.",
+	}
+}
+
+func (r *ReleaseBundleReceivedResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ReleaseBundleReceivedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ReleaseBundleReceivedResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ReleaseBundleReceivedAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		SetResult(&result).
+		Get(ReceivedEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+
+func (r *ReleaseBundleReceivedResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ReleaseBundleReceivedResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		Delete(ReceivedEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}

--- a/pkg/distribution/resource_release_bundle_received_test.go
+++ b/pkg/distribution/resource_release_bundle_received_test.go
@@ -1,0 +1,32 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccReleaseBundleReceived_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReleaseBundleReceivedConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccReleaseBundleReceivedConfig_basic() string {
+	return `
+resource "distribution_received" "test" {
+  name = "test-value"
+  version = "test-value"
+}
+`
+}


### PR DESCRIPTION
## New Resource

Adds `distribution_release_bundle_received` resource to the Distribution provider.

### APIs Covered

- `GET distribution/api/v2/release_bundle/received/{name}`

### CRUD Operations

| Operation | Supported |
|---|---|
| Create | No |
| Read | Yes |
| Update | No |
| Delete | No |

### Files Changed

- `resource_release_bundle_received.go`
- `resource_release_bundle_received_test.go`

### Provider Coverage

**Before:** 65/69 (94.2%)
**After (est.):** 66/69 (95.7%)

### Test Plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Acceptance test `TestAccReleaseBundleReceived_basic` passes
- [ ] Import test passes

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*