### PR TITLE
[New Resource] Add distribution_distribution (CU) — 2 APIs

### DIFF
--- a/pkg/distribution/resource_distribution.go
+++ b/pkg/distribution/resource_distribution.go
@@ -1,0 +1,207 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	DistributionsEndpoint = "distribution/api/v1"
+	DistributionEndpoint  = "distribution/api/v1/distribution/{name}/{version}"
+)
+
+func NewDistributionResource() resource.Resource {
+	return &DistributionResource{
+		TypeName: "distribution_distribution",
+	}
+}
+
+type DistributionResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type DistributionResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Version types.String `tfsdk:"version"`
+}
+
+type DistributionRequestAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+type DistributionAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (r *DistributionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *DistributionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				Description: "The name of the resource.",
+			},
+			"version": schema.StringAttribute{
+				Required: true,
+				Description: "The version of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages distribution in JFrog Distribution.",
+	}
+}
+
+func (r *DistributionResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *DistributionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan DistributionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := DistributionRequestAPIModel{
+		Name: plan.Name.ValueString(),
+		Version: plan.Version.ValueString(),
+	}
+
+	var result DistributionAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(DistributionsEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *DistributionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state DistributionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result DistributionAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		SetResult(&result).
+		Get(DistributionEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+func (r *DistributionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	go util.SendUsageResourceUpdate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan DistributionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := DistributionRequestAPIModel{
+		Name: plan.Name.ValueString(),
+		Version: plan.Version.ValueString(),
+	}
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": plan.Name.ValueString(),
+			"version": plan.Version.ValueString(),
+		}).
+		SetBody(requestBody).
+		Put(DistributionEndpoint)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToUpdateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+
+func (r *DistributionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state DistributionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		Delete(DistributionEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}

--- a/pkg/distribution/resource_distribution_test.go
+++ b/pkg/distribution/resource_distribution_test.go
@@ -1,0 +1,32 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDistribution_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccDistributionConfig_basic() string {
+	return `
+resource "distribution_distribution" "test" {
+  name = "test-value"
+  version = "test-value"
+}
+`
+}


### PR DESCRIPTION
## New Resource

Adds `distribution_distribution` resource to the Distribution provider.

### APIs Covered

- `PUT distribution/api/v1/distribution`
- `POST distribution/api/v1/distribution`

### CRUD Operations

| Operation | Supported |
|---|---|
| Create | Yes |
| Read | No |
| Update | Yes |
| Delete | No |

### Files Changed

- `resource_distribution.go`
- `resource_distribution_test.go`

### Provider Coverage

**Before:** 65/69 (94.2%)
**After (est.):** 67/69 (97.1%)

### Test Plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Acceptance test `TestAccDistribution_basic` passes
- [ ] Import test passes

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*