### PR TITLE
[New Resource] Add distribution_export_release_bundle (CD) — 2 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 (March 16, 2026)
+
+FEATURES:
+
+* **New Resource:** `distribution_export_release_bundle` PR: [#41](https://github.com/jfrog/terraform-provider-distribution/pull/41)
+
 ## 1.3.0 (October 13, 2025). Tested on Artifactory 7.124.1 with Terraform 1.13.3 and OpenTofu 1.10.6
 
 FEATURES:

--- a/pkg/distribution/resource_export_release_bundle.go
+++ b/pkg/distribution/resource_export_release_bundle.go
@@ -1,0 +1,174 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ReleaseBundleEndpoint = "distribution/api/v1/export/release_bundle/{name}/{version}"
+	ReleaseBundleEndpoint  = "distribution/api/v1/export/release_bundle/{name}/{version}"
+)
+
+func NewExportReleaseBundleResource() resource.Resource {
+	return &ExportReleaseBundleResource{
+		TypeName: "distribution_release_bundle",
+	}
+}
+
+type ExportReleaseBundleResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ExportReleaseBundleResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Version types.String `tfsdk:"version"`
+}
+
+type ReleaseBundleRequestAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ReleaseBundleAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (r *ExportReleaseBundleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ExportReleaseBundleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				Description: "The name of the resource.",
+			},
+			"version": schema.StringAttribute{
+				Required: true,
+				Description: "The version of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages release_bundle in JFrog Distribution.",
+	}
+}
+
+func (r *ExportReleaseBundleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *ExportReleaseBundleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan ExportReleaseBundleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := ExportReleaseBundleRequestAPIModel{
+		Name: plan.Name.ValueString(),
+		Version: plan.Version.ValueString(),
+	}
+
+	var result ExportReleaseBundleAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(ReleaseBundleEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *ExportReleaseBundleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ExportReleaseBundleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ExportReleaseBundleAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		SetResult(&result).
+		Get(ReleaseBundleEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+
+func (r *ExportReleaseBundleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ExportReleaseBundleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		Delete(ReleaseBundleEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}
+

--- a/pkg/distribution/resource_export_release_bundle_test.go
+++ b/pkg/distribution/resource_export_release_bundle_test.go
@@ -1,0 +1,32 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccExportReleaseBundle_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportReleaseBundleConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccExportReleaseBundleConfig_basic() string {
+	return `
+resource "distribution_release_bundle" "test" {
+  name = "test-value"
+  version = "test-value"
+}
+`
+}


### PR DESCRIPTION
## Summary

Add `distribution_export_release_bundle` resource (Create | Delete).

### APIs

- `POST distribution/api/v1/export/release_bundle/{name}/{version}`
- `DELETE distribution/api/v1/export/release_bundle/{name}/{version}`

### Files

- `resource_export_release_bundle.go`
- `resource_export_release_bundle_test.go`
- `CHANGELOG.md`

### Coverage

21/78 (26.9%) → 23/78 (29.5%)

### Checklist

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `TestAccExportReleaseBundle_basic`

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*
