### PR TITLE
[New Resource] Add distribution_received_artifacts (R) — 1 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 (March 16, 2026)
+
+FEATURES:
+
+* **New Resource:** `distribution_received_artifacts` PR: [#42](https://github.com/jfrog/terraform-provider-distribution/pull/42)
+
 ## 1.3.0 (October 13, 2025). Tested on Artifactory 7.124.1 with Terraform 1.13.3 and OpenTofu 1.10.6
 
 FEATURES:

--- a/pkg/distribution/resource_received_artifacts.go
+++ b/pkg/distribution/resource_received_artifacts.go
@@ -1,0 +1,109 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ArtifactsEndpoint = "distribution/api/v2/release_bundle/received/{name}/{version}/artifacts"
+	ArtifactsEndpoint  = "distribution/api/v2/release_bundle/received/{name}/{version}/artifacts"
+)
+
+func NewReceivedArtifactsResource() resource.Resource {
+	return &ReceivedArtifactsResource{
+		TypeName: "distribution_artifacts",
+	}
+}
+
+type ReceivedArtifactsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ReceivedArtifactsResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Version types.String `tfsdk:"version"`
+}
+
+type ArtifactsAPIModel struct {
+	Name string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (r *ReceivedArtifactsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ReceivedArtifactsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				Description: "The name of the resource.",
+			},
+			"version": schema.StringAttribute{
+				Required: true,
+				Description: "The version of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages artifacts in JFrog Distribution.",
+	}
+}
+
+func (r *ReceivedArtifactsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ReceivedArtifactsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ReceivedArtifactsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ReceivedArtifactsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"name": state.Name.ValueString(),
+			"version": state.Version.ValueString(),
+		}).
+		SetResult(&result).
+		Get(ArtifactsEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/distribution/resource_received_artifacts_test.go
+++ b/pkg/distribution/resource_received_artifacts_test.go
@@ -1,0 +1,32 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccReceivedArtifacts_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReceivedArtifactsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccReceivedArtifactsConfig_basic() string {
+	return `
+resource "distribution_artifacts" "test" {
+  name = "test-value"
+  version = "test-value"
+}
+`
+}


### PR DESCRIPTION
## Summary

Add `distribution_received_artifacts` resource (Read).

### APIs

- `GET distribution/api/v2/release_bundle/received/{name}/{version}/artifacts`

### Files

- `resource_received_artifacts.go`
- `resource_received_artifacts_test.go`
- `CHANGELOG.md`

### Coverage

21/78 (26.9%) → 22/78 (28.2%)

### Checklist

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `TestAccReceivedArtifacts_basic`

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*
