### PR TITLE
[New Resource] Add distribution_system_settings (CR) — 2 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 (March 16, 2026)
+
+FEATURES:
+
+* **New Resource:** `distribution_system_settings` PR: [#61](https://github.com/jfrog/terraform-provider-distribution/pull/61)
+
 ## 1.3.0 (October 13, 2025). Tested on Artifactory 7.124.1 with Terraform 1.13.3 and OpenTofu 1.10.6
 
 FEATURES:

--- a/pkg/distribution/resource_system_settings.go
+++ b/pkg/distribution/resource_system_settings.go
@@ -1,0 +1,137 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	SettingssEndpoint = "distribution/api/v1/system/settings"
+	SettingssEndpoint  = "distribution/api/v1/system/settings"
+)
+
+func NewSystemSettingsResource() resource.Resource {
+	return &SystemSettingsResource{
+		TypeName: "distribution_settings",
+	}
+}
+
+type SystemSettingsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SystemSettingsResourceModel struct {
+	CallHomeEnabled types.Bool `tfsdk:"call_home_enabled"`
+}
+
+type SettingsRequestAPIModel struct {
+	CallHomeEnabled string `json:"call_home_enabled"`
+}
+
+type SettingsAPIModel struct {
+	CallHomeEnabled string `json:"call_home_enabled"`
+}
+
+func (r *SystemSettingsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SystemSettingsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"call_home_enabled": schema.StringAttribute{
+				Optional: true,
+				Description: "If enabled, sending usage statistics to JFrog",
+			},
+		},
+		MarkdownDescription: "Manages settings in JFrog Distribution.",
+	}
+}
+
+func (r *SystemSettingsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *SystemSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan SystemSettingsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := SystemSettingsRequestAPIModel{
+		CallHomeEnabled: plan.CallHomeEnabled.ValueString(),
+	}
+
+	var result SystemSettingsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(SettingssEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *SystemSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SystemSettingsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SystemSettingsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(SettingssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/distribution/resource_system_settings_test.go
+++ b/pkg/distribution/resource_system_settings_test.go
@@ -1,0 +1,30 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSystemSettings_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemSettingsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSystemSettingsConfig_basic() string {
+	return `
+resource "distribution_settings" "test" {
+}
+`
+}


### PR DESCRIPTION
## Summary

Add `distribution_system_settings` resource (Create | Read).

### APIs

- `GET distribution/api/v1/system/settings`
- `POST distribution/api/v1/system/settings`

### Files

- `resource_system_settings.go`
- `resource_system_settings_test.go`
- `CHANGELOG.md`

### Coverage

21/78 (26.9%) → 23/78 (29.5%)

### Checklist

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `TestAccSystemSettings_basic`

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*
